### PR TITLE
Added build and solution files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,10 @@ jobs:
       - name: Display SemVer
         run: |
             echo "SemVer: $GITVERSION_SEMVER"
-
+          
+      - name: Add DbUp NuGet Source
+        run: dotnet nuget add source --name DbUp --username DbUp --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text https://nuget.pkg.github.com/DbUp/index.json
+        
       - name: Restore
         run: dotnet restore
         working-directory: src

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Display SemVer
         run: |
-            echo "SemVer: $GITVERSION_SEMVER"
+            echo "SemVer: $env:GitVersion_SemVer"
           
       - name: Add DbUp NuGet Source
         run: dotnet nuget add source --name DbUp --username DbUp --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text https://nuget.pkg.github.com/DbUp/index.json
@@ -43,7 +43,7 @@ jobs:
         working-directory: src
 
       - name: Build
-        run: dotnet build -c Release --no-restore /p:Version=$GITVERSION_SEMVER
+        run: dotnet build -c Release --no-restore /p:Version=$env:GitVersion_SemVer
         working-directory: src
 
       - name: Test
@@ -51,13 +51,13 @@ jobs:
         working-directory: src
 
       - name: Pack
-        run: dotnet pack --no-build -c Release -o ../artifacts /p:Version=$GITVERSION_SEMVER
+        run: dotnet pack --no-build -c Release -o ../artifacts /p:Version=$env:GitVersion_SemVer
         working-directory: src
 
       - name: Upload NuGet packages as artifacts ⬆️
         uses: actions/upload-artifact@v3
         with:
-          path: artifacts/dbup-redshift.$GITVERSION_SEMVER.nupkg
+          path: artifacts/dbup-redshift.$env:GitVersion_SemVer.nupkg
 
       - name: Test Report 🧪
         uses: dorny/test-reporter@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-latest  # Use Ubuntu in v5.0
 
     env:
       DOTNET_NOLOGO: true
@@ -17,6 +17,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # all
+
+      - name: Setup .NET 2.0 # Remove in v5.0
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 2.0.x
 
       - name: Setup .NET 6.0
         uses: actions/setup-dotnet@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,65 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    env:
+      DOTNET_NOLOGO: true
+      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true # Avoid pre-populating the NuGet package cache
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # all
+
+      - name: Setup .NET 6.0
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 6.0.x
+
+      - name: Install GitVersion
+        uses: gittools/actions/gitversion/setup@v0.9.7
+        with:
+          versionSpec: '5.x'
+
+      - name: Run GitVersion
+        uses: gittools/actions/gitversion/execute@v0.9.7
+
+      - name: Display SemVer
+        run: |
+            echo "SemVer: $GITVERSION_SEMVER"
+
+      - name: Restore
+        run: dotnet restore
+        working-directory: src
+
+      - name: Build
+        run: dotnet build -c Release --no-restore /p:Version=$GITVERSION_SEMVER
+        working-directory: src
+
+      - name: Test
+        run: dotnet test --no-build --logger trx --logger console;verbosity=detailed --results-directory ../artifacts
+        working-directory: src
+
+      - name: Pack
+        run: dotnet pack --no-build -c Release -o ../artifacts /p:Version=$GITVERSION_SEMVER
+        working-directory: src
+
+      - name: Upload NuGet packages as artifacts ⬆️
+        uses: actions/upload-artifact@v3
+        with:
+          path: artifacts/dbup-redshift.$GITVERSION_SEMVER.nupkg
+
+      - name: Test Report 🧪
+        uses: dorny/test-reporter@v1
+        if: ${{ always() }}
+        with:
+          name: Tests
+          path: artifacts/*.trx
+          reporter: dotnet-trx

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     env:
       DOTNET_NOLOGO: true
@@ -47,7 +47,7 @@ jobs:
         working-directory: src
 
       - name: Test
-        run: dotnet test --no-build --logger trx --logger console;verbosity=detailed --results-directory ../artifacts
+        run: dotnet test --no-build -c Release --logger trx --logger "console;verbosity=detailed" --results-directory ../artifacts
         working-directory: src
 
       - name: Pack

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Upload NuGet packages as artifacts ⬆️
         uses: actions/upload-artifact@v3
         with:
-          path: artifacts/dbup-redshift.$env:GitVersion_SemVer.nupkg
+          path: artifacts/dbup-redshift.*.nupkg
 
       - name: Test Report 🧪
         uses: dorny/test-reporter@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,10 +59,9 @@ jobs:
         run: dotnet pack --no-build -c Release -o ../artifacts /p:Version=$env:GitVersion_SemVer
         working-directory: src
 
-      - name: Upload NuGet packages as artifacts ⬆️
-        uses: actions/upload-artifact@v3
-        with:
-          path: artifacts/dbup-redshift.*.nupkg
+      - name: Push NuGet packages to GitHub Packages ⬆️
+        working-directory: artifacts
+        run: dotnet nuget push dbup-redshift.$env:GitVersion_SemVer.nupkg --api-key ${{ secrets.GITHUB_TOKEN }} --source "https://nuget.pkg.github.com/DbUp/index.json"
 
       - name: Test Report 🧪
         uses: dorny/test-reporter@v1

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,0 +1,1 @@
+mode: Mainline

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+[![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/DbUp/dbup-redshift/CI/main)](https://github.com/DbUp/dbup-redshift/actions/workflows/main.yml?query=branch%3Amain)
+[![NuGet](https://img.shields.io/nuget/dt/dbup-redshift.svg)](https://www.nuget.org/packages/dbup-redshift)
+[![NuGet](https://img.shields.io/nuget/v/dbup-redshift.svg)](https://www.nuget.org/packages/dbup-redshift)
+[![Prerelease](https://img.shields.io/nuget/vpre/dbup-redshift?color=orange&label=prerelease)](https://www.nuget.org/packages/dbup-redshift)
+
+# DbUp Redshift support
+DbUp is a .NET library that helps you to deploy changes to SQL Server databases. It tracks which SQL scripts have been run already, and runs the change scripts that are needed to get your database up to date.
+
+## Getting Help
+To learn more about DbUp check out the [documentation](https://dbup.readthedocs.io/en/latest/)
+
+Please only log issue related to Redshift support in this repo. For cross cutting issues, please use our [main issue list](https://github.com/DbUp/DbUp/issues).
+
+# Contributing
+
+See the [readme in our main repo](https://github.com/DbUp/DbUp/blob/master/README.md) for how to get started and contribute.

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -23,10 +23,5 @@
     <Compile Remove="ApprovalFiles\*.cs" />
     <None Include="ApprovalFiles\*.cs" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="DbUp.Tests.Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>bin\Debug\net461\DbUp.Tests.Common.dll</HintPath>
-    </Reference>
-  </ItemGroup>
+  
 </Project>

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
+    <AssemblyName>Tests</AssemblyName>
+    <RootNamespace>DbUp.Redshift.Tests</RootNamespace>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <!--    <ImplicitUsings>enable</ImplicitUsings> Can't use implict usings with net46 -->
+    <Nullable>enable</Nullable>
+    <NoWarn>$(NoWarn);NETSDK1138</NoWarn> <!-- Purposefully leaving an old version of netcoreapp to ensure we have compatibility. This never gets published -->
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\dbup-redshift\dbup-redshift.csproj" />
+    <PackageReference Include="DbUp.Tests.Common" Version="4.6.5-SeperateProviderTests.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="ApprovalFiles\*.cs" />
+    <None Include="ApprovalFiles\*.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="DbUp.Tests.Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>bin\Debug\net461\DbUp.Tests.Common.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+</Project>

--- a/src/dbup-redshift.sln
+++ b/src/dbup-redshift.sln
@@ -6,7 +6,23 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests", "Tests\Tests.csproj
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_", "_", "{2BB18839-D96E-4697-902D-1900A6B75F69}"
 	ProjectSection(SolutionItems) = preProject
-		Directory.Build.props = Directory.Build.props
+		..\.gitattributes = ..\.gitattributes
+		..\.gitignore = ..\.gitignore
+		..\license.txt = ..\license.txt
+		..\README.md = ..\README.md
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{62E5FE92-E288-4E09-964D-F92AF0E49131}"
+	ProjectSection(SolutionItems) = preProject
+		..\.github\workflows\main.yml = ..\.github\workflows\main.yml
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{5DA19CA9-8039-46D6-B474-021943582785}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{77157734-01DA-4AA3-A15C-504013343B29}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+		dbup-redshift.sln.DotSettings = dbup-redshift.sln.DotSettings
 	EndProjectSection
 EndProject
 Global
@@ -23,5 +39,10 @@ Global
 		{8CE634FE-6772-408E-9340-909F6218F8F7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8CE634FE-6772-408E-9340-909F6218F8F7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8CE634FE-6772-408E-9340-909F6218F8F7}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{62E5FE92-E288-4E09-964D-F92AF0E49131} = {5DA19CA9-8039-46D6-B474-021943582785}
+		{77157734-01DA-4AA3-A15C-504013343B29} = {2BB18839-D96E-4697-902D-1900A6B75F69}
+		{5DA19CA9-8039-46D6-B474-021943582785} = {2BB18839-D96E-4697-902D-1900A6B75F69}
 	EndGlobalSection
 EndGlobal

--- a/src/dbup-redshift.sln
+++ b/src/dbup-redshift.sln
@@ -1,0 +1,27 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "dbup-redshift", "dbup-redshift\dbup-redshift.csproj", "{2A7189BD-96CE-41CA-9100-E1B1DD10FF40}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests", "Tests\Tests.csproj", "{8CE634FE-6772-408E-9340-909F6218F8F7}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_", "_", "{2BB18839-D96E-4697-902D-1900A6B75F69}"
+	ProjectSection(SolutionItems) = preProject
+		Directory.Build.props = Directory.Build.props
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{2A7189BD-96CE-41CA-9100-E1B1DD10FF40}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2A7189BD-96CE-41CA-9100-E1B1DD10FF40}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2A7189BD-96CE-41CA-9100-E1B1DD10FF40}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2A7189BD-96CE-41CA-9100-E1B1DD10FF40}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8CE634FE-6772-408E-9340-909F6218F8F7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8CE634FE-6772-408E-9340-909F6218F8F7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8CE634FE-6772-408E-9340-909F6218F8F7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8CE634FE-6772-408E-9340-909F6218F8F7}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/src/dbup-redshift/Properties/AssemblyInfo.cs
+++ b/src/dbup-redshift/Properties/AssemblyInfo.cs
@@ -1,14 +1,5 @@
 ﻿using System;
-using System.Reflection;
 using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("dbup_redshift")]
-[assembly: AssemblyTrademark("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/src/dbup-redshift/dbup-redshift.csproj
+++ b/src/dbup-redshift/dbup-redshift.csproj
@@ -9,19 +9,17 @@
     <AssemblyOriginatorKeyFile>../dbup.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+    <Product>dbup_redshift</Product>
     <PackageId>dbup-redshift</PackageId>
     <PackageIcon>dbup-icon.png</PackageIcon>
-    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
-    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
-    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net35'">
     <DefineConstants>$(DefineConstants);NPGSQLv2</DefineConstants>
   </PropertyGroup>
-  
+
   <ItemGroup>
-    <ProjectReference Include="..\dbup-core\dbup-core.csproj" />
+    <PackageReference Include="dbup-core" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net35'">
@@ -33,7 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Visible="false" Include="../../dbup-icon.png" Pack="True" PackagePath="" />
+    <None Visible="false" Include="../dbup-icon.png" Pack="True" PackagePath="" />
   </ItemGroup>
-  
+
 </Project>

--- a/src/dbup-redshift/dbup-redshift.csproj
+++ b/src/dbup-redshift/dbup-redshift.csproj
@@ -9,6 +9,7 @@
     <AssemblyOriginatorKeyFile>../dbup.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+    <RepositoryUrl>https://github.com/DbUp/dbup-redshift.git</RepositoryUrl>
     <Product>dbup_redshift</Product>
     <PackageId>dbup-redshift</PackageId>
     <PackageIcon>dbup-icon.png</PackageIcon>


### PR DESCRIPTION
This completes the move of the redshift provider to it's own repo. See https://github.com/DbUp/DbUp/issues/431 for reasoning for the move

**It'd be worth making sure this project is structured and built the way we want as I intend to use this as a template for all the other provider moves.**

TODO in future PRs:
- Pushing to NuGet
- Issue templates

This is the end of a chain of PR:
#2 and https://github.com/DbUp/DbUp/pull/631 - Move files from existing repo
https://github.com/DbUp/DbUp/pull/627 and https://github.com/DbUp/DbUp/pull/631 to set us up for the move