### PR TITLE
Breaking Change: Update to net8.0 and Npgsql 9.0.2

### DIFF
--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -14,9 +14,9 @@
   <ItemGroup>
     <ProjectReference Include="..\dbup-redshift\dbup-redshift.csproj" />
     <PackageReference Include="DbUp.Tests.Common" Version="6.0.0-beta.146" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/dbup-redshift/dbup-redshift.csproj
+++ b/src/dbup-redshift/dbup-redshift.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Description>DbUp makes it easy to deploy and upgrade SQL Server databases. This package adds Amazon Redshift support.</Description>
         <Title>DbUp Redshift Support</Title>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <AssemblyName>dbup-redshift</AssemblyName>
         <RootNamespace>DbUp.Redshift</RootNamespace>
         <AssemblyOriginatorKeyFile>../dbup.snk</AssemblyOriginatorKeyFile>
@@ -22,7 +22,7 @@
     
     <ItemGroup>
         <PackageReference Include="dbup-core" Version="6.0.3" />
-        <PackageReference Include="Npgsql" Version="8.0.5" />
+        <PackageReference Include="Npgsql" Version="9.0.2" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Similar to https://github.com/DbUp/dbup-postgresql/pull/24

Looks like Npgsql has dropped support for netstandard2.0 so in order to keep on top of patches this library should do the same. Going to net8.0 as it's the only supported LTS.